### PR TITLE
Fix Whisper loading error with PyTorch 2.6

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ YTDLP_VIDEO_FORMAT="bestvideo[height<=720]+bestaudio/best[height<=720]"
 # API key for Gemini
 GOOGLE_API_KEY=your-google-api-key
 
-# Path to a custom Whisper model (.pt or .gguf)
+# Path to a custom Whisper model (.pt)
 WHISPER_MODEL_PATH=/path/to/whisper-model
 
 CLIP_PADDING=1.5           # Seconds of padding around clips


### PR DESCRIPTION
## Summary
- retry Whisper model load with `weights_only=False` if default fails
- clarify `.env.example` comment on Whisper model format

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c98efcccc83228d301ef973a2050a