### PR TITLE
Fix fuzzy timestamp padding

### DIFF
--- a/scripts/processors/youtube_processor.py
+++ b/scripts/processors/youtube_processor.py
@@ -264,8 +264,8 @@ class YouTubeProcessor:
                     if adjusted_ratio > best_ratio:
                         best_ratio = adjusted_ratio
                         # Add context padding to the timestamps
-                        padded_start = max(0, start - context_padding) if start else None
-                        padded_end = (end + context_padding) if end else None
+                        padded_start = max(0, start - context_padding) if start is not None else None
+                        padded_end = (end + context_padding) if end is not None else None
                         best_result = (padded_start, padded_end, combined.strip())
                         
                         logging.debug("New best match: ratio=%.3f, adjusted=%.3f, words=%d, coverage=%.2f", 

--- a/tests/test_find_quote_timestamps.py
+++ b/tests/test_find_quote_timestamps.py
@@ -27,7 +27,7 @@ class FindQuoteTimestampTests(unittest.TestCase):
             {"start": 2.0, "end": 3.0, "text": "and runs away"},
         ]
         quote = "quick brown fox jumps over the lazy dog"
-        start, end, snippet = find_quote_timestamps(segments, quote)
+        start, end, snippet = find_quote_timestamps(segments, quote, context_padding=0.0)
         self.assertEqual(start, 0.0)
         self.assertEqual(end, 2.0)
         self.assertIn("quick brown fox jumps over the lazy dog", snippet.lower())
@@ -38,7 +38,7 @@ class FindQuoteTimestampTests(unittest.TestCase):
             {"start": 1.0, "end": 2.0, "text": "to learn from data and make predictions"},
         ]
         quote = "machine learning lets computers learn from data to make predictions"
-        start, end, snippet = find_quote_timestamps(segments, quote)
+        start, end, snippet = find_quote_timestamps(segments, quote, context_padding=0.0)
         self.assertEqual(start, 0.0)
         self.assertEqual(end, 2.0)
         self.assertIsNotNone(snippet)

--- a/tests/test_generate_posts_from_text.py
+++ b/tests/test_generate_posts_from_text.py
@@ -33,7 +33,7 @@ class GeneratePostsTests(unittest.TestCase):
             '[{"post_text": "first", "source_quote": "q1"}]',
             '[{"post_text": "second", "source_quote": "q2"}]',
         ])
-        main.load_llm = lambda: stub
+        main.load_llm = lambda backend=None: stub
 
         func = main.generate_posts_from_text
         system_prompt = func.__code__.co_consts[1]
@@ -57,7 +57,7 @@ class GeneratePostsTests(unittest.TestCase):
         stub = StubLLM([
             "<think>\nHere is your data:\n[{\"post_text\": \"foo\", \"source_quote\": \"bar\"}]"
         ])
-        main.load_llm = lambda: stub
+        main.load_llm = lambda backend=None: stub
         posts = main.generate_posts_from_text("hello", "text")
         self.assertEqual(len(posts), 1)
         self.assertEqual(posts[0]["post_text"], "foo")
@@ -66,7 +66,7 @@ class GeneratePostsTests(unittest.TestCase):
         stub = StubLLM([
             "<think>doing stuff</think>[{\"post_text\": \"tagged\", \"source_quote\": \"bar\"}]"
         ])
-        main.load_llm = lambda: stub
+        main.load_llm = lambda backend=None: stub
         posts = main.generate_posts_from_text("hello", "text")
         self.assertEqual(len(posts), 1)
         self.assertEqual(posts[0]["post_text"], "tagged")
@@ -75,7 +75,7 @@ class GeneratePostsTests(unittest.TestCase):
         stub = StubLLM([
             '[{\"post_text\": \"tagless\", \"source_quote\": \"bar\"}]</think>'
         ])
-        main.load_llm = lambda: stub
+        main.load_llm = lambda backend=None: stub
         posts = main.generate_posts_from_text("hello", "text")
         self.assertEqual(len(posts), 1)
         self.assertEqual(posts[0]["post_text"], "tagless")
@@ -84,26 +84,26 @@ class GeneratePostsTests(unittest.TestCase):
         output = ("You are a bot. Return an empty JSON array [] if you cannot comply. "
             "Actual data: [{\"post_text\": \"ok\", \"source_quote\": \"q\"}]")
         stub = StubLLM([output])
-        main.load_llm = lambda: stub
+        main.load_llm = lambda backend=None: stub
         posts = main.generate_posts_from_text("hello", "text")
         self.assertEqual(len(posts), 1)
         self.assertEqual(posts[0]["post_text"], "ok")
 
     def test_invalid_json_shape_dict(self):
         stub = StubLLM(['{"foo": "bar"}'])
-        main.load_llm = lambda: stub
+        main.load_llm = lambda backend=None: stub
         with self.assertRaises(ValueError):
             main.generate_posts_from_text("hello", "text")
 
     def test_invalid_json_shape_array_elements(self):
         stub = StubLLM(['["a", "b"]'])
-        main.load_llm = lambda: stub
+        main.load_llm = lambda backend=None: stub
         with self.assertRaises(ValueError):
             main.generate_posts_from_text("hello", "text")
 
     def test_single_post_object(self):
         stub = StubLLM(['{"post_text": "solo", "source_quote": "q"}'])
-        main.load_llm = lambda: stub
+        main.load_llm = lambda backend=None: stub
         posts = main.generate_posts_from_text("hello", "text")
         self.assertEqual(len(posts), 1)
         self.assertEqual(posts[0]["post_text"], "solo")


### PR DESCRIPTION
## Summary
- prevent dropping timestamp 0 due to falsey check in YouTubeProcessor
- update unit tests for new `load_llm` signature and quote padding behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cb7684a3c832287ce5dc3bfe8372b