### PR TITLE
Add whisper.cpp support

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -103,6 +103,9 @@ for tips on exporting cookies.
 To limit the resolution (and thus file size) of downloaded videos, set
 `YTDLP_VIDEO_FORMAT` to a yt_dlp format string. It defaults to
 `bestvideo[height<=720]+bestaudio/best[height<=720]`.
+To use a whisper.cpp model set `WHISPER_BACKEND=cpp` and
+`WHISPER_MODEL_PATH` to the `.gguf` file. The helper falls back to the
+standard OpenAI Whisper library otherwise.
 Set `GOOGLE_API_KEY` when using the Gemini model.
 Example:
 ```bash

--- a/README.md
+++ b/README.md
@@ -41,7 +41,12 @@ You can also reduce the size of downloaded videos by limiting the format used by
 example `bestvideo[height<=720]+bestaudio/best[height<=720]`). This value
 defaults to that 720p-limited string when unset.
 
-To use the Gemini 2.5 Pro Preview model set `GOOGLE_API_KEY` in your environment.
+To load a local [whisper.cpp](https://github.com/ggerganov/whisper.cpp) model
+set `WHISPER_BACKEND=cpp` and point `WHISPER_MODEL_PATH` to the `.gguf` file.
+The helper script will automatically use the `whispercpp` library when either
+the backend is "cpp" or the path ends in `.gguf`.
+
+To use the Gemini 2.0 Flash model set `GOOGLE_API_KEY` in your environment.
 The home page lets you pick either the local Phi model or Gemini from a drop‑down.
 
 If you want to brand generated clips with a watermark image, place

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ openai-whisper
 llama-cpp-python
 python-dotenv
 google-generativeai
+whispercpp

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -24,6 +24,11 @@ except Exception:
 from llama_cpp import Llama
 import whisper
 
+try:  # optional whisper.cpp binding
+    import whispercpp
+except Exception:  # pragma: no cover - optional dependency
+    whispercpp = None
+
 # --- Configuration ---
 MODEL_DIRECTORY = os.path.expanduser("~/.cache/lm-studio/models")
 
@@ -43,6 +48,10 @@ WHISPER_MODEL_NAME = "base.en"
 # path to a model file so we expand the user's home directory and provide that
 # path.
 WHISPER_MODEL_PATH = os.path.expanduser("~/whisper_models/base.en.pt")
+
+# When WHISPER_BACKEND is set to "cpp" or the model path ends with "gguf" the
+# helper loads the model via whispercpp.
+WHISPER_BACKEND = os.getenv("WHISPER_BACKEND", "auto")
 
 
 # Folder where generated media assets are stored under the repository root
@@ -119,7 +128,7 @@ WHISPER_TRANSCRIBER = None
 
 
 class GeminiLLM:
-    def __init__(self, model_name: str = "gemini-2.5-pro-preview"):
+    def __init__(self, model_name: str = "gemini-2.0-flash"):
         import google.generativeai as genai  # pragma: no cover - optional
         api_key = os.getenv("GOOGLE_API_KEY")
         if not api_key:
@@ -167,8 +176,15 @@ def load_whisper():
     global WHISPER_TRANSCRIBER
     if WHISPER_TRANSCRIBER is None:
         model_path = WHISPER_MODEL_PATH if os.path.exists(WHISPER_MODEL_PATH) else WHISPER_MODEL_NAME
-        logging.info("Loading Whisper model %s", model_path)
-        WHISPER_TRANSCRIBER = whisper.load_model(model_path)
+        use_cpp = WHISPER_BACKEND == "cpp" or str(model_path).endswith(".gguf")
+        if use_cpp:
+            if whispercpp is None:
+                raise RuntimeError("whispercpp library not installed")
+            logging.info("Loading whisper.cpp model %s", model_path)
+            WHISPER_TRANSCRIBER = whispercpp.Whisper(model_path)
+        else:
+            logging.info("Loading Whisper model %s", model_path)
+            WHISPER_TRANSCRIBER = whisper.load_model(model_path)
         logging.info("Whisper model loaded")
     return WHISPER_TRANSCRIBER
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -138,7 +138,7 @@ export default function HomePage() {
                             className="w-full p-2 border rounded bg-gray-50 dark:bg-gray-700 dark:border-gray-600"
                         >
                             <option value="phi">Phi 3.1 Mini (local)</option>
-                            <option value="gemini">Gemini 2.5 Pro Preview</option>
+                            <option value="gemini">Gemini 2.0 Flash</option>
                         </select>
                     </div>
                     <button type="submit" disabled={isLoading} className="w-full bg-blue-600 text-white font-bold py-2 px-4 rounded hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed flex items-center justify-center">


### PR DESCRIPTION
## Summary
- support whisper.cpp models in the helper script
- document new `WHISPER_BACKEND` option
- add `whispercpp` dependency
- fix Gemini model name

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68501b12bf9c8322a3fec9be6c7baa74