### PR TITLE
Add DeepSeek-R1 local model option

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -93,7 +93,7 @@ The script accepts four arguments:
 ```bash
 python scripts/main.py <input_type> <input_data> <job_id> [llm_model]
 ```
-`<input_type>` is `youtube`, `pdf` or `text`. `<input_data>` is a URL, file path or text. `<job_id>` can be any identifier (the web app generates one automatically). `[llm_model]` is `phi` or `gemini` and defaults to `gemini`.
+`<input_type>` is `youtube`, `pdf` or `text`. `<input_data>` is a URL, file path or text. `<job_id>` can be any identifier (the web app generates one automatically). `[llm_model]` is `phi`, `deepseek-r1` or `gemini` and defaults to `gemini`.
 If a YouTube video requires authentication, create a `.env` file in the project
 root with `YTDLP_COOKIE_FILE` set to the path of a browser-exported cookies
 file. The Python helper automatically loads `.env` if present. Consult the

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ example `bestvideo[height<=720]+bestaudio/best[height<=720]`). This value
 defaults to that 720p-limited string when unset.
 
 To use the Gemini 2.5 Flash Preview (model `gemini-2.5-flash-preview-05-20`) set `GOOGLE_API_KEY` in your environment.
-The home page lets you pick either the local Phi model or Gemini from a drop‑down.
+The home page lets you pick from Gemini or one of the local models (Phi or DeepSeek‑R1) using a drop‑down.
 
 If you want to brand generated clips with a watermark image, place
 `aiprepperWM.png` in the `public` folder or set the `WATERMARK_PATH`

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -27,12 +27,20 @@ import whisper
 # --- Configuration ---
 MODEL_DIRECTORY = os.path.expanduser("~/.cache/lm-studio/models")
 
-# LLaMA-style text generator model
-# Default to the Phi-3.1-mini model with a 128k token context window
-LLM_MODEL_PATH = os.path.join(
-    MODEL_DIRECTORY,
-    "lmstudio-community/Phi-3.1-mini-128k-instruct-GGUF/Phi-3.1-mini-128k-instruct-Q4_K_M.gguf",
-)
+# LLaMA-style text generator models
+LOCAL_LLM_MODELS = {
+    "phi": os.path.join(
+        MODEL_DIRECTORY,
+        "lmstudio-community/Phi-3.1-mini-128k-instruct-GGUF/Phi-3.1-mini-128k-instruct-Q4_K_M.gguf",
+    ),
+    "deepseek-r1": os.path.join(
+        MODEL_DIRECTORY,
+        "unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/DeepSeek-R1-Distill-Qwen-1.5B-Q8_0.gguf",
+    ),
+}
+
+# Default local model
+LLM_MODEL_PATH = LOCAL_LLM_MODELS["phi"]
 
 # Whisper model identifier or path accepted by the openai-whisper library. We
 # default to the "base.en" model name but also allow specifying a path to a
@@ -179,9 +187,10 @@ def load_llm(backend: str | None = None):
             logging.info("Loading Gemini model")
             LLM_TEXT_GENERATOR = GeminiLLM()
         else:
-            logging.info("Loading LLaMA model from %s", LLM_MODEL_PATH)
+            model_file = LOCAL_LLM_MODELS.get(backend, LLM_MODEL_PATH)
+            logging.info("Loading LLaMA model from %s", model_file)
             LLM_TEXT_GENERATOR = Llama(
-                model_path=LLM_MODEL_PATH,
+                model_path=model_file,
                 n_gpu_layers=-1,
                 n_ctx=8192,
                 verbose=True,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,7 @@ export default function HomePage() {
     const [inputType, setInputType] = useState<InputType>('youtube');
     const [inputValue, setInputValue] = useState('');
     const [pdfFile, setPdfFile] = useState<File | null>(null);
-    type ModelType = 'phi' | 'gemini';
+    type ModelType = 'phi' | 'deepseek-r1' | 'gemini';
     const [model, setModel] = useState<ModelType>('gemini');
     const [isLoading, setIsLoading] = useState(false);
     const [jobId, setJobId] = useState<string | null>(null);
@@ -138,6 +138,7 @@ export default function HomePage() {
                             className="w-full p-2 border rounded bg-gray-50 dark:bg-gray-700 dark:border-gray-600"
                         >
                             <option value="phi">Phi 3.1 Mini (local)</option>
+                            <option value="deepseek-r1">DeepSeek R1 Distill (local)</option>
                             <option value="gemini">Gemini 2.5 Flash Preview (05-20)</option>
                         </select>
                     </div>


### PR DESCRIPTION
## Summary
- support `deepseek-r1` in Python helper
- add model choice in UI dropdown
- document new model in README and Developer Guide

## Testing
- `npm run lint` *(fails: next not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850e641f6308322a2aa70c9c7c30402