### PR TITLE
Update gemini model

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can also reduce the size of downloaded videos by limiting the format used by
 example `bestvideo[height<=720]+bestaudio/best[height<=720]`). This value
 defaults to that 720p-limited string when unset.
 
-To use the Gemini 2.5 Flash Preview (model `gemini-2.5-flash-preview-05-20`) set `GOOGLE_API_KEY` in your environment.
+To use the Gemini 2.0 Flash Lite model (`gemini-2.0-flash-lite`) set `GOOGLE_API_KEY` in your environment.
 The home page lets you pick from Gemini or one of the local models (Phi or DeepSeek‑R1) using a drop‑down.
 
 If you want to brand generated clips with a watermark image, place

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -127,7 +127,7 @@ WHISPER_TRANSCRIBER = None
 
 
 class GeminiLLM:
-    def __init__(self, model_name: str = "gemini-2.5-flash-preview-05-20"):
+    def __init__(self, model_name: str = "gemini-2.0-flash-lite"):
         import google.generativeai as genai  # pragma: no cover - optional
         api_key = os.getenv("GOOGLE_API_KEY")
         if not api_key:

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -139,7 +139,7 @@ export default function HomePage() {
                         >
                             <option value="phi">Phi 3.1 Mini (local)</option>
                             <option value="deepseek-r1">DeepSeek R1 Distill (local)</option>
-                            <option value="gemini">Gemini 2.5 Flash Preview (05-20)</option>
+                            <option value="gemini">Gemini 2.0 Flash Lite</option>
                         </select>
                     </div>
                     <button type="submit" disabled={isLoading} className="w-full bg-blue-600 text-white font-bold py-2 px-4 rounded hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed flex items-center justify-center">


### PR DESCRIPTION
## Summary
- use `gemini-2.0-flash-lite` as the default Gemini model
- adjust the label in the Next.js dropdown
- update documentation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850e75764708322a3ec43321979595a